### PR TITLE
v1.02 Spot tracker shows integration&backg size, bug fixes

### DIFF
--- a/src/LEED_Commands.java
+++ b/src/LEED_Commands.java
@@ -55,7 +55,7 @@ public class LEED_Commands extends PlugInFrame implements MouseListener {
             "(Plugins>Utilities>Find Commands, or type "+LeedUtils.CTRL+"-L)</p>"+
             "<ul>"+
             "<li><b>Open LEED Movie</b> opens a ViPErLEED movie stored as a .zip file or an 'AIDA' LEED movie "+
-            "(Automatic Image and Data Acquisition, EE2000/EE2010; *.vid format). LEED movies are shown as "+
+            "(Automatic Image and Data Acquisition, EE2000/EE2010; <tt>*.vid</tt> format). LEED movies are shown as "+
             "<em>Image Stacks</em> in ImageJ.</li>"+
             "<li>The <b>Spot Tracker</b> is used to extract <i>I</i>(<i>V</i>) curves from a LEED movie.</li>"+
             "<li>The <b>I(V) Curve Editor</b> is used for selection and smoothing of experimental <i>I</i>(<i>V</i>) curves.</li>"+

--- a/src/LEED_Curve_Editor.java
+++ b/src/LEED_Curve_Editor.java
@@ -69,7 +69,7 @@ public class LEED_Curve_Editor implements PlugIn, DialogListener, ActionListener
             "<html>"+
             "<h1>Parameters and Settings for the ViPErLEED I(V) Curve Editor</h1>"+
             "<ul>"+
-            "<li><b>V0i</b>: Imaginary part of the inner potential  (strictly speaking, its absolute value), needed for calculating the R factor. "+
+            "<li><b>V0i</b>: Imaginary part of the inner potential  (strictly speaking, its absolute value), needed for calculating the <i>R</i> factor. "+
             "When averaging symmetry-equivalent curves that do not all include the full energy range, "+
             "V0i also determines the width of the transition zone with smooth fade in/fade out. "+
             "If V0i is not known, use, e.g., a value of 5 eV.</li>"+
@@ -79,8 +79,8 @@ public class LEED_Curve_Editor implements PlugIn, DialogListener, ActionListener
             "If a <a href='#editFile'>previous edit file</a> is used, "+
             "this setting has no effect and the value from the previous session is used.</li>"+
             "<li><b>Min. data range per curve</b>: Curves with fewer contiguous data points than this are ignored. "+
-            "Note that you cannot make ignored curves (with too few points) visible any more in the current editing session "+
-            "(You have to close &amp; open the Curve Editor to get them back).</li>"+
+            "Note that you cannot make ignored curves (with too few points) visible any more in the current editing session. "+
+            "You have to close and open the Curve Editor to get them back.</li>"+
             "<li><b>Lowest energy to use</b> and <b>Highest energy to use</b>: "+
             "The default energy range  if a beam is selected for the first time. "+
             "These parameters also limit the range for automatic (noise-dependent) selection of energy ranges. "+

--- a/src/LEED_IV_Curve_Interpolation.java
+++ b/src/LEED_IV_Curve_Interpolation.java
@@ -94,7 +94,7 @@ public class LEED_IV_Curve_Interpolation implements PlugIn {
         LeedIVData ivData = LeedIVData.fromFile(filePath, null, LeedIVData.ZERO_IS_NAN);
         if (ivData == null || ivData.energies == null)
             return;
-      
+
         LeedIVData newData = LeedInterpolator.interpolate(ivData, newStep);
         
         IJ.showStatus("Saving...");

--- a/src/LEED_IV_Curve_Tools.java
+++ b/src/LEED_IV_Curve_Tools.java
@@ -87,7 +87,7 @@ public class LEED_IV_Curve_Tools implements PlugIn, DialogListener {
             "You can select the new indices of the (1,0) and (0,1) spots. "+
             "You can use this function, e.g., to swap the <i>h</i> and <i>k</i> indices: Change (1,0) to (0,1) and (0,1) to (1,0). "+
             "Swapping <i>h</i> and <i>k</i> is often needed for crystals with threefold symmetry, where (1,0) and (0,1) are not equivalent, "+
-            "but is is initially not known which is which.<br>"+
+            "but it is initially not known which is which.<br>"+
             "If the spot labels have included group numbers in square brackets (to indicate the symmetry-equivalent beams, "+
             "see below), these group numbers will be deleted."+
             "</li>"+

--- a/src/LICENSE_GPLv3.txt
+++ b/src/LICENSE_GPLv3.txt
@@ -1,0 +1,622 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+

--- a/src/LeedCurvePlotEditor.java
+++ b/src/LeedCurvePlotEditor.java
@@ -105,8 +105,8 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
     private static final String GO_LAST       = "Go to highest group";
     private static final String GO_PREV_COMMENT   = "Go to previous group with a comment";
     private static final String GO_NEXT_COMMENT  = "Go to next group with a comment";
-    private static final String GO_PREV_BAD   = "Go to previous 'bad beam agreement' ["+LeedUtils.CTRL+" ,]";
-    private static final String GO_NEXT_BAD   = "Go to next 'bad beam agreement' ["+LeedUtils.CTRL+" .]";
+    private static final String GO_PREV_BAD   = "Go to previous 'bad beam agreement' ["+LeedUtils.CTRL+" <]";
+    private static final String GO_NEXT_BAD   = "Go to next 'bad beam agreement' ["+LeedUtils.CTRL+" >]";
     private static final String GO_HIGHEST    = "Go to highest selected group";
     private static final String GO_INDEX      = "Go to beam index/beam group...";
     private static final String SELECT_ALL    = "Select all groups";
@@ -248,7 +248,7 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "their average (red) and the smoothed average in the selected range (black).</li>"+
             "<li>The <b>top part</b> of the plot area shows the <i>Y</i> function "+
             "(modified logarithmic derivative used in Pendry's <i>R</i> factor), "+
-            "for the averaged I(V) curve (red) and the smoothed I(V) curve (black). "+
+            "for the averaged <i>I</i>(<i>V</i>) curve (red) and the smoothed <i>I</i>(<i>V</i>) curve (black). "+
             "This is the function that is compared to the corresponding function of the calculated <i>I</i>(<i>V</i>) curves.</li>"+
             "<li>Small, colored <b>ticks</b> below the <i>Y</i> function indicate the limits of the data ranges of the individual <i>I</i>(<i>V</i>) curves. "+
             "Thicker and longer ticks indicate an excluded energy range of an input beam.</li>"+
@@ -260,21 +260,22 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "Comments are saved in the <a href='#editFile'>edit file</a>.</li>"+
             "<li><b>Save</b> saves the csv file with the final curves. Right-click to save the data without smoothing.</li>"+
             "<li>The <b>&lt;</b> and <b>&gt;</b> buttons switch to the previous/next group of symmetry-equivalent beams. "+
-            "Keyboard shortcut: '&lt;' or ',' and '&gt;' or '.'. The &lt;Page Up&gt;, &lt;Page Down&gt;, &lt;Home&gt;, "+
+            "Keyboard shortcut: '&lt;' or ',' and '&gt;' or '.' (on non-English keyboards, ',' and '.' keys work only "+
+            "if this is the main function of the key, without pressing the shift key). The &lt;Page Up&gt;, &lt;Page Down&gt;, &lt;Home&gt;, "+
             "and &lt;End&gt; keys also work. Alternatively, you can use the mouse wheel.<br>"+
             "Right-click for more navigation options: First, last, or last selected beam group. "+
             "You can also jump to the previous or next beam group with a comment, or "+
             "previous or next group with bad agreement of equivalent beams (for the latter, only selected groups and energy ranges count). "+
             "You can also enter the beam indices or group number for jumping to a group."+
             "</li>"+
-            "<li><b>Select/Deselect</b> (on/off symbol) selects whether the curves of the currently "+
+            "<li><b>Group On/Off</b> (on/off symbol) selects whether the curves of the currently "+
             "shown group of symmetry-equivalent beams should be used at all.<br>"+
             "Keyboard shortcut: SPACE bar.<br>"+
             "Right-click to select or deselect all groups. "+
-            "(Note that 'Select all groups' does not select groups where the energy span be "+
+            "(Note that 'Select all groups' does not select groups where the energy span is "+
             "less than the <a href='#energyRange'>minimum span</a>.) "+
             "The '<a href='#autoSelect'>Auto Select</a>' function available via right-clicking does not only switch groups on/off "+
-            "but also selects the energy ranges.</li>"+
+            "but also selects the energy ranges, maximizing a figure of merit that depends on the noise.</li>"+
             "<li><b>Smooth More/Less</b> selects how much the curve (or average of curves) will be smoothed. "+
             "You can modify smoothing also with the &lt;ALT&gt; key down and the mouse wheel. Press &lt;SHIFT&gt; for a faster change.<br>"+
             "Right-click to change the (default) smoothing for all deselected (switched-off) groups "+
@@ -284,30 +285,28 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "and slightly weaker smoothing for less noisy curves.<br>"+
             "The 'Set best smoothing [vs. simulated I(V)]' option asks for a file of simulated <i>I</i>(<i>V</i>) curves (<tt>THEOBEAMS.csv</tt> file). "+
             "It then tries different smoothing parameters to find the smoothing that results in the lowest <i>R</i> factor "+
-            "between smoothed experimental and simulated curves, and applies this smoothing.</li>"+
-            "<li><a name='energyRange'><b>Energy Range</b></a> (yellow rectangle): "+
+            "between smoothed experimental and simulated curves, and applies this smoothing. "+
+            "This should be done only as the very last step, after refinement of the structure and inner potential.</li>"+
+            "<li><a name='energyRange'><b>Set Energy Range</b></a> (yellow rectangle): "+
             "Use the ImageJ Rectangle tool from the main ImageJ Toolbar to select the energy range and then press this button.<br>"+
             "Keyboard shortcut: '#' or '0'.<br>"+
             "Only the left and right sides of the selection rectangle are taken into account. "+
             "When the left or right side is close to the limit of one of the input curves, "+
             "and a slight shift of the boundary would avoid the necessity to smoothly fade in or fade out of that curve, "+
             "the range snaps to this point. "+
-            "You can override the snap with a right-click on the Energy Range button and "+
+            "You can override the snap with a right-click on the 'Set Energy Range' button and "+
             "'Set energy range to current ROI (no snap)'.<br>"+
             "For a given beam group, only one energy range can be selected. In other words, you can't have a gap in the output data. "+
-            "(This restriction is required by TensErLEED, which used as a backend for "+
+            "(This restriction is required by TensErLEED, which is used as a backend for "+
             "LEED-<i>I</i>(<i>V</i>) calculations in <tt>viperleed.calc</tt>.)<br>"+
-            "When there is no selection and 'Energy Range' button is pressed, the default energy range is used. "+
-            "This is the range from the dialog window shown when opening the Curve Editor, "+
-            "uless it has been modified by 'Set energy limits' from the context menu of the 'Energy Range' button. "+
-            "The 'Energy Range' button also selects a curve if it was deselected.<br>"+
-            "At low energies, if you have symmetry-equivalent curves, exclude the lowest energies if the shapes "+
-            "of the curves for symmetry-equivalent beams differ substantially. "+
-            "(Deviations between symmetry-equivalent beams at low energies only are typically due to residual magnetic fields; "+
-            "deviations at all energies are more likely due deviations from normal incidence. "+
-            "Very large deviations may indicate that you have the wrong spot pattern file, i.e., the symmetry is wrong.)<br>"+
-            "With right-clicking the Energy Range button, one can also set the full energy range of the curve, or "+
-            "modify the default energy range or the minimum energy span (previously specified in the starting dialog), "+
+            "When there is no selection and 'Set Energy Range' button is pressed, the default energy range is used. "+
+            "This is defined by the limits from the dialog window shown when opening the Curve Editor, "+
+            "unless it has been modified by 'Set energy limits' from the context menu of the 'Set Energy Range' button. "+
+            "The 'Set Energy Range' button also selects a curve if it was deselected.<br>"+
+            "By right-clicking the 'Set Energy Range' button, one can also set the full energy range for the curve, "+
+            "or the default energy range (as given by the limits). "+
+            "You can also modify these limits (the default energy range) or the minimum energy span "+
+            "(previously specified in the starting dialog), "+
             "and optionally restrict the energy ranges of all groups to obey the new limits. "+
             "<b><a href='#autoSelect'>Automatic selection</a></b> of beam groups and energy ranges (depending on the noise) "+
             "is also available from this context menu.<br>"+
@@ -316,7 +315,11 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "If there is no sufficiently long low-noise range, deselect the whole curve. "+
             "Rule of thumb: For 0.5 eV energy steps, in the ideal case, the noise (peak\u2013peak) "+
             "should be on average less than ~20\u201330% of the full vertical range of the <i>Y</i> function. "+
-            "Select the high-energy limit such that high-energy regions with an average noise larger than this noise are excluded. "+
+            "Select the high-energy limit such that high-energy regions with an average noise larger than this noise are excluded.<br>"+
+            "If symmetry-equivalent beams differ substantially in the low-energy region, exclude these low energies. "+
+            "(Deviations between symmetry-equivalent beams at low energies only are typically due to residual magnetic fields; "+
+            "deviations at all energies are more likely due deviations from normal incidence. "+
+            "Very large deviations may indicate that you have the wrong spot pattern file, i.e., the symmetry is wrong.)<br>"+
             "</li>"+
             "<li><a name='ivEditorOptions'><b>Options</b></a> (gearwheel symbol): Use the 'Options...' dialog to change the V0i value, "+
             "use a fixed <i>x</i> axis with the full energy range for all curves, "+
@@ -327,7 +330,8 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "the Spot Tracker: This shows the current energy of the Spot Tracker as a black vertical line in the I(V) Curve Editor. "+
             "The beams of the current beam group in the I(V) Curve Editor can be highlighted in the Spot Tracker "+
             "(unless the highlighted beams of the Spot Tracker still mark the dubious beams of spot tracking; these are not modified).<br>"+
-            "The 'Options' button also lets you select the threshold for classifying '<b>bad agreement</b>' of symmetry-equivalent beams and "+
+            "By right-clicking the 'Options' button, you can select the threshold for classifying "+
+            "'<b>bad agreement</b>' of symmetry-equivalent beams and "+
             "create a list of these 'bad-agreement' beams. "+
             "A typical value for this threshold is between the threshold value for "+
             "<a href='#autoSelect'>automatic selection</a> and twice that value. "+
@@ -354,7 +358,7 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "<p>If you have taken more than one <i>I</i>(<i>V</i>) movie for averaging, "+
             "average their <i>I</i>(<i>V</i>) curves before using the I(V) Curve Editor.</p>"+
             "<p>When opening the (averaged) <i>I</i>(<i>V</i>) curve for the first time, "+
-            "start with <b><a name='autoSelect'>automatic selection</a></b> (also available later with right-clicking the on/off or 'set energy range' button) "+
+            "start with <b><a name='autoSelect'>automatic selection</a></b> (also available later with right-clicking the on/off or 'Set Energy Range' button) "+
             "to select the energy ranges for all curves. Automatic selection is based on an "+
             "estimate of the noise of the curve and its impact on the <i>R</i> factor. "+
             "Selection is done such that the average noise is less than the given noise limit and a figure of merit "+
@@ -374,14 +378,14 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             LeedUtils.CTRL+"-next group). The energy of the worst agreement of a given beam with the average "+
             "will be marked by a vertical line. You may move the mouse over the button for this beam to compare its "+
             "<i>Y</i> function with that of the average. Sometimes, the bad agreement is caused by a defect of the LEED screen "+
-            "(if only one out of many beams is an outlier) and a short section of the 'bad' beam can be excluded. "+
-            "(Select the 'bad' energy range and exclude it for the beam by right-clicking on its button.) "+
+            "(if only one out of many beams is an outlier) and a short section of the 'bad' beam can be excluded: "+
+            "Select the 'bad' energy range and exclude it for the beam by right-clicking on its button. "+
             "In other cases, especially if such a 'bad' region is close to the ends of the energy range, "+
             "it makes sense to set the energy range for the beam group such that the region of poor agreement is avoided. "+
             "If many groups show large disagreement of the symmetry-equivalent beams, "+
             "consider repeating the measurement with better adjustment of perpendicular incidence and/or "+
             "better compensation of residual magnetic fields.</p>"+
-            "<p>Finally, save the data. You can now use them as input for structure optimization (file EXPBEAMS.csv).</p>"+
+            "<p>Finally, save the data. You can now use them as input for structure optimization (file <tt>EXPBEAMS.csv</tt>).</p>"+
             "<p>Towards the end of a LEED <i>I</i>(<i>V</i>) study, when you have a good best-fit model from the simulation calculations, "+
             "you may want to try the 'Set best smoothing [vs. simulated I(V)]' option (right-click one of the smoothing buttons) "+
             "for the last tweak (typically with 'noise-dependent smoothing' enabled). Usually, the improvement of the <i>R</i> factor "+
@@ -403,7 +407,7 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
             "You can set a fixed energy range corresponding to this full range in the <a href='#ivEditorOptions'>Options</a>.</p>"+
             "<p>If you want a different color for the selection rectangle, you can set it in ImageJ: Edit&gt;&gt;Options&gt;&gt;Colors...</p>"+
             "<p>You can have more than one I(V) Curve Editor window at the same time, to compare different sets of <i>I</i>(<i>V</i>) curves. "+
-            "These windows get synchronized, i.e., they show the same beam group (if available) and the same energy range on the <i>x</i> axis.</p>"+
+            "These windows are synchronized, i.e., they show the same beam group (if available) and the same energy range on the <i>x</i> axis.</p>"+
             "<p>Smoothing is performed using a 4th-degree modified-sinc smoother [<a href='#msSmooth'>2</a>]. "+
             "The best smoothing parameter is typically 0.6&nbsp;V0i "+
             "(very good data or energies &lt; 50 eV) to 1.3&nbsp;V0i (noisy data). "+
@@ -659,7 +663,9 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
         }
         double minY=Double.MAX_VALUE, maxY=-Double.MAX_VALUE;
         for (int d=Y_AVG; d<N_PLOT_DATA; d++) {     //data range for Y_AVG, Y_SMOOTH
-            double[] minMax = Tools.getMinMax(processedData[d]);
+            double[] pData = processedData[d];
+            if (pData == null) continue;
+            double[] minMax = Tools.getMinMax(pData);
             if (minY > minMax[0]) minY = minMax[0];
             if (maxY < minMax[1]) maxY = minMax[1];
         }
@@ -2713,6 +2719,8 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
     void handleButtonPressed(int button, MouseEvent e) {
         if (guiBlocked()) return;
         boolean isRightClick = LeedUtils.isPopupTrigger(e);
+        int modifiers = e==null ? 0 : e.getModifiersEx();
+        boolean ctrlOrMeta = (modifiers & (InputEvent.CTRL_DOWN_MASK | InputEvent.META_DOWN_MASK)) != 0;
         if (isRightClick || button == OPTIONS) {
             if (CONTEXT_MENU_ITEMS[Math.min(button, N_BUTTONS)] != null)
                 showMenu(button, getCanvas(), e);
@@ -2726,10 +2734,16 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
                     saveCurves(true);
                     break;
                 case PREV:
-                    setGroup(getPreviousGroup(), true);
+                    if (ctrlOrMeta)
+                        goBadGroup(-1);
+                    else
+                        setGroup(getPreviousGroup(), true);
                     break;
                 case NEXT:
-                    setGroup(getNextGroup(), true);
+                    if (ctrlOrMeta)
+                        goBadGroup( 1);
+                    else
+                        setGroup(getNextGroup(), true);
                     break;
                 case ON_OFF:
                     boolean useOut = useOutput[currentColumns[0]];
@@ -2837,7 +2851,7 @@ public class LeedCurvePlotEditor implements Runnable, MouseListener, MouseMotion
                         str += " Current range: "+IJ.d2s(energies[currentRange[0]], E_DECIMALS)+
                                 "-"+energies[Math.max(currentRange[1]-1,0)];
                 } else
-                    str ="Set energy range "+IJ.d2s(Math.max(eMinMax[0],curveStartEv), E_DECIMALS)+
+                    str ="Set Energy Range "+IJ.d2s(Math.max(eMinMax[0],curveStartEv), E_DECIMALS)+
                             "-"+IJ.d2s(Math.min(eMinMax[1], curveEndEv), E_DECIMALS);
                 str += ". Right-click for more. Shortcut: # or 0";
                 break;

--- a/src/LeedDarkFlatVirtualStack.java
+++ b/src/LeedDarkFlatVirtualStack.java
@@ -459,6 +459,8 @@ public class LeedDarkFlatVirtualStack extends VirtualStack {
                 cacheRefs[n] = doStrongCaching ? new SoftReference<float[]>(pixels) : new WeakReference<float[]>(pixels);
         } else {
             pixels = (float[])sourceIp.convertToFloat().getPixels();
+            if (sourceIp != null && pixels == sourceIp.getPixels())
+                pixels = (float[])pixels.clone();   //make sure we can't overwrite the original
         }
 
         nWorkingThreads.decrementAndGet();

--- a/src/LeedInterpolator.java
+++ b/src/LeedInterpolator.java
@@ -86,8 +86,15 @@ public class LeedInterpolator {
         for (int iRange=0; iRange<rangeLimits.length/2; iRange++) {
             int rStart = rangeLimits[2*iRange];
             int rEnd = rangeLimits[2*iRange+1];
-            int newStart = (int)Math.ceil((oldX[rStart]-newX[0])/newStep - 1e-10);
-            int newEnd = (int)Math.floor((oldX[rEnd-1]-newX[0])/newStep + 1e-10) + 1;
+            double oldXstart = oldX[rStart];
+            double oldXend = oldX[rEnd-1];
+            if (oldXstart > oldXend) {              //allow for inverse x axis at the input
+                double swaptmp = oldXend;
+                oldXend = oldXstart;
+                oldXstart = swaptmp;
+            }
+            int newStart = (int)Math.ceil((oldXstart-newX[0])/newStep - 1e-10);
+            int newEnd = (int)Math.floor((oldXend-newX[0])/newStep + 1e-10) + 1;
             if (newStart < 0) newStart = 0;
             if (newEnd > newX.length) newEnd = newX.length;
             if (newEnd - newStart < 1) continue;    //nothing to do in output array
@@ -105,6 +112,11 @@ public class LeedInterpolator {
             int firstValid, int endValid, int newStart, int newEnd) {
         float[] oldXF = extractFloat(oldX, firstValid, endValid);
         float[] oldDF = extractFloat(oldData, firstValid, endValid);
+        boolean inverse = oldXF[0] > oldXF[oldXF.length - 1];
+        if (inverse) {
+            LeedUtils.reverseArray(oldXF);
+            LeedUtils.reverseArray(oldDF);
+        }
         SplineFitter spline = new SplineFitter(oldXF, oldDF, endValid-firstValid);
         for (int i=newStart; i<newEnd; i++) {
             double x = newX[i];

--- a/src/LeedLinearRegression.java
+++ b/src/LeedLinearRegression.java
@@ -107,6 +107,7 @@ public class LeedLinearRegression {
         double r = (sumXY - sumX*sumY*(1/counter)) / Math.sqrt(stdX2TimesN*stdY2TimesN);
         if (counter > 1e-100 && Double.isNaN(r)) r = 1; //if stddev of y = 0;
         rmsResiduals = stdY2TimesN*(1/counter)*(1 - r*r);
+        if (rmsResiduals < 0) rmsResiduals = 0;         //numerical errors could cause rmsResiduals<0
         // alternative equation: (sumY2 + slope*slope*sumX2 + offset*offset*counter - 2*slope*sumXY - 2*offset*sumY + 2*offset*slope*sumX) / counter;
         calculated = true;
 		//DEBUG IJ.log("off="+(float)offset+" sl="+(float)slope+" r2="+(float)(r*r)+" rmsR="+(float)rmsResiduals);

--- a/src/LeedMaskCreator.java
+++ b/src/LeedMaskCreator.java
@@ -8,6 +8,7 @@ import ij.plugin.filter.RankFilters;
 import ij.plugin.filter.ThresholdToSelection;
 import ij.gui.*;
 import java.awt.*;
+import java.util.Arrays;
 
 
 /**
@@ -236,6 +237,8 @@ public class LeedMaskCreator implements Runnable, DialogListener {
         int width = ip.getWidth();
         int height = ip.getHeight();
         double[] roiParams = ((EllipseRoi)ellipseOutlineRoi).getParams();
+        //IJ.log("Ellipse w,h="+width+","+height+";roiParams="+Arrays.toString(roiParams));
+        if (LeedUtils.countNonNaN(roiParams) != roiParams.length) return null;
         double xC = 0.5*(roiParams[0] + roiParams[2]);
         double yC = 0.5*(roiParams[1] + roiParams[3]);
         double vLength = Math.sqrt(sqr(roiParams[0] - roiParams[2]) + sqr(roiParams[1] - roiParams[3]));

--- a/src/LeedParams.java
+++ b/src/LeedParams.java
@@ -181,7 +181,7 @@ public class LeedParams {
             3.0,                                    // AZIMUTHBLURANGLE (half-angle in degrees)
             30,                                     // POSITIONAVERAGINGEV
             2.5,                                    // MINSIGNIFICANCETRACK
-            30.,                                    // SEARCHAGAINEV
+            10.,                                    // SEARCHAGAINEV
             1,                                      // NEIGHBORBACKGROUND
             0,                                      // I0FROMBACKGR
             2.0,                                    // MINSIGNIFICANCEINDEX
@@ -497,7 +497,7 @@ public class LeedParams {
     /** Displays a table of numeric parameter differences */
     private static void tabulateDifferences(String filename, double[] fileParams, double[] params) {
         ResultsTable rt = new ResultsTable();
-        for (int i=0; i<N_PARAM; i++) {
+        for (int i=1; i<N_PARAM; i++) {         //ignore 0, version
             if (fileParams[i] != params[i]) {
                 rt.incrementCounter();
                 rt.addLabel(NUMERIC_PARAM_NAMES[i]);

--- a/src/LeedRFactor.java
+++ b/src/LeedRFactor.java
@@ -35,7 +35,7 @@ public class LeedRFactor {
     public static final int AVG_INTENSITY = 4;          //average intensity of the curves (actually sqrt(average intensity 1 * average intensity 2)
     public static final int N_OVERLAP = 5;              //number of points in common region of the curves
     public static final int RATIO = 6;                  //ratio of data2/data1 average
-    public static final int OUTPUT_SIZE = 7;
+    public static final int OUTPUT_SIZE = 7;            //the length of the output array 0...6
     public static final String[] R_FACTOR_NAMES = new String[] {"R_Pendry", "R_PeMod"};
 
 

--- a/src/LeedSpotTrackerHelp.java
+++ b/src/LeedSpotTrackerHelp.java
@@ -39,14 +39,14 @@ public class LeedSpotTrackerHelp {
             "<dt>Dark Frame and Flat Field (optional)</dt><dd>";
     private static final String HELP_DARKFLATEXPLAIN =
             "These images should be used to correct for the dark current of the camera (and background illumination, if any) "+
-            "as well as inhomogeneities of the LEED screen, optics and camera. The <em>flat field</em> is an image "+
+            "as well as inhomogeneities of the LEED screen, optics, and camera. The <em>flat field</em> is an image "+
             "(or image stack) of a diffuse diffraction pattern with no spots, only showing the inhomogeneities "+
             "of the optics and camera. The flat field is typically recorded by moving a polycrystalline "+
             "sample holder to the sample position; make sure that the distance from the electron source "+
             "is exactly the same as that of the sample surface. (Since the intensity is spread out over all the screen, "+
             "you may use a higher beam current or longer exposure than for the LEED movie of the sample.) "+
             "A flat field is especially important if the LEED image has a high "+
-            "background intensity, e.g. for sample temperatures around or above the Debye temperature of the sample. "+
+            "background intensity, e.g., for sample temperatures around or above the Debye temperature of the sample. "+
             "<em>Dark frame</em> images (when present) are subtracted from the input stack and flat field before "+
             "the flat-field correction. The dark frame is best measured with a high negative Wehnelt voltage, "+
             "suppressing the beam, but keeping light emitted by the filament as well as any glow due to (field-emitted) "+
@@ -72,7 +72,7 @@ public class LeedSpotTrackerHelp {
             "The type of dark & amp;flat processing is displayed in abbreviated form next to the "+
             "<a href='#darkFlatProcessing'>Dark &amp; Flat Processing</a> button. "+
             "Some sort of averaging (to reduce the noise) is advisable, especially for the flat field.<br>&nbsp;&nbsp;&nbsp;&nbsp;"+
-            "Note that image processing with dark &amp; flat requires a <em>mask</em> (see below). "+
+            "Note that image processing with dark and flat requires a <em>mask</em> (see below). "+
             "The mask defines the area where the correction will be performed. "+
             "Without a proper mask, the correction will result in arbitrary values outside the LEED screen; "+
             "this will prevent proper setting of brightness &amp; contrast and may make the LEED screen appear black or dull.";
@@ -80,18 +80,19 @@ public class LeedSpotTrackerHelp {
             "</dd><dt>Mask (required)</dt><dd>An 8-bit image (&quot;binary image&quot;) with white pixels "+
             "for the background and black for the foreground. The foreground area determines the screen area "+
             "where intensities may be measured. The mask image must NOT contain pixel values other than 0 or 255. "+
-            "You can use Analyze&gt;Histogram to see which pixel values are present in an image; "+
-            "in the histogram panel click on &quot;Log&quot; (=logarithmic) to see also values that occur "+
-            "for a few pixels only. You can use Image&gt;Adjust&gt;Threshold (and &quot;Apply&quot;) "+
+            "You can use <i>Analyze&gt;Histogram</i> to see which pixel values are present in an image; "+
+            "in the histogram panel click on &quot;Log&quot; (logarithmic <i>y</i> axis scale) to see also values that occur "+
+            "for a few pixels only. You can use <i>Image&gt;Adjust&gt;Threshold</i> (and &quot;Apply&quot;) "+
             "to ensure that all pixel values are 0 or 255. Images with in-between values cannot be selected as a mask.<br>&nbsp;&nbsp;&nbsp;&nbsp;"+
             "You have to create the Mask image; start with <a href='#createMask'>More&gt;&gt;Create Mask</a>. "+
             "As soon as a mask has been selected, it is shown as an outline on the image stack used for spot tracking. "+
             "Editing of the mask image will be reflected by the outline almost immediately.</dd>"+
             "</dl>"+
-            "<p>All these images or image stacks must be open in ImageJ; you can use More&gt;&gt;Open Images/Movies... "+
+            "<p>All these images or image stacks must be open in ImageJ; you can use <a href='#openImagesMovies'>More&gt;&gt;Open Images/Movies...</a> "+
             " to open them (and select them as the input, if appropriate). Alternatively, you can use the "+
-            "Plugins&gt;ViPErLEED&gt;Open LEED Movie... command (which can also create a table of metadata when opening a movie) "+
-            "or the various ImageJ File&gt;Open and File&gt;Import commands (e.g. File&gt;Import&gt;Image Sequence...) "+
+            "<i>Plugins&gt;ViPErLEED&gt;Open LEED Movie...</i> command (which can also create a table of metadata when opening a movie) "+
+            "or the various ImageJ <i>File&gt;Open</i> and <i>File&gt;Import</i> commands "+
+            "(e.g. <i>File&gt;Import&gt;Image Sequence...</i>) "+
             "for combining multiple images into an image stack (i.e., a movie). "+
             "Image stacks may be in memory or (if the open/import command allows) they can be <em>virtual stacks</em>, "+
             "i.e., the active image is read from disk as required, but not always kept in memory (needs less RAM).<br>&nbsp;&nbsp;&nbsp;&nbsp;"+
@@ -110,9 +111,9 @@ public class LeedSpotTrackerHelp {
             "- Smoothing: Select this option for averaging over a few energies (usually used for the flat field). "+
             "The <i>Smooth amount</i> determines the noise suppression. "+
             "(For a smooth amount of <i>n</i>, the noise suppression is roughly equivalent to that of averaging over <i>n</i> "+
-            "points, but the algorithm is actually different from moving averages, with better suppression "+
+            "stack slices, but the algorithm is actually different from moving averages, with better suppression "+
             "of rapid fluctuations and less memory use.)</p>"+
-            "<p><i>Flat field processing</i>: Before applying the flat field "+
+            "<p><i>Flat field processing type</i>: Before applying the flat field "+
             "(and after subtraction of its dark frame, if provided) to the main image, "+
             "in most cases further processing of the flat field should be applied: "+
             "If the flat field is a stack with 1:1 correspondence to the input "+
@@ -152,14 +153,14 @@ public class LeedSpotTrackerHelp {
             "either using the individual values for each energy or a linear fit "+
             "(if the dark frames are a stack with 1:1 correspondence to the main input stack). "+
             "I00 may be read from the dark frame(s) only if they were obtained without emitted electron current "+
-            "(not by setting the screen voltage to 0). "+
+            "(i.e., by setting the Wehnelt voltage to a highly negative value, not by setting the screen voltage to 0). "+
             "If I00 is provided, the actual beam current is calculated as <tt>I0 - I00</tt>. "+
             "Usually, the beam current should be smoothed; the amount of smoothing can be entered (0 for no smoothing). "+
             "The amount of smoothing is given as the number of points in a moving-averages filter "+
             "with the same noise suppression; actually a modified sinc kernel [<a href= '#msSmooth'>2</a>] is used. "+
             "I0, I00, and the smoothed and I00-corrected beam current are plotted after closing this input window "+
             "if 'Plot I0' is selected. The plot does not include corrections based on the background intensity "+
-            "measured during spot tracking (after spot tracking, you can use 'More&gt;&gt;Plot...' for this).</p>"+
+            "measured during spot tracking (after spot tracking, you can use <a href='#morePlot'>More&gt;&gt;Plot...</a> for this).</p>"+
             "<p>This input window also has an option to set LEEM mode. In LEEM mode, it is assumed that "+
             "the spots do not move with energy as they would in normal LEED experiments.</p>"+
             "<p>For experiments with constant electron energy, such as studies of phase transitions "+
@@ -183,17 +184,17 @@ public class LeedSpotTrackerHelp {
             "<p>Firstly, an input window appears and asks you to select a stack slice "+
             "[an energy in usual <i>I</i>(<i>V</i>) measurements] where as many spots as possible are clearly visible, "+
             "including spots near the edge of the screen. Use the slider below the '<tt>..._SpotTracking</tt>' image stack "+
-            "to select the energy (You cannot use one of the image stacks supplied as the input for energy selection, "+
-            "unless it is coupled with the '<tt>..._SpotTracking</tt>' stack via Analyze&gt;Tools&gt;Synchronize Windows). "+
+            "to select the energy (For energy selection, you cannot use one of the image stacks supplied as the input, "+
+            "unless it is coupled with the '<tt>..._SpotTracking</tt>' stack via <i>Analyze&gt;Tools&gt;Synchronize Windows</i>). "+
             "You may use the <tt>Auto</tt> button of the "+
-            "Image&gt;Adjust&gt;Brightness&amp;Contrast panel (B&amp;C; keyboard shortcut "+LeedUtils.CTRL+"-SHIFT-C when the stack "+
+            "<i>Image&gt;Adjust&gt;Brightness&amp;Contrast panel</i> (B&amp;C; keyboard shortcut "+LeedUtils.CTRL+"-SHIFT-C when the stack "+
             "is in the foreground) or the sliders of the B&amp;C "+
             "panel to adjust the contrast. If many spots are not recognized (not marked by "+
             "a circle), or many circles do not mark diffraction maxima, you can adjust the noise rejection. "+
             "Note that also an improper value of the <a href='#setRadius'>integration radius</a> may prevent recognition of the spots. "+
             "Having a few 'false' spots marked does not hurt as long as these are not close to the position where "+
             "a diffraction maximum would be expected.</p>"+
-            "<p>When spot indices have been defined previously and fit the the maxima, the maxima will be labeled "+
+            "<p>When spot indices have been defined previously and fit the maxima, the maxima will be labeled "+
             "and you can click 'Labels are OK' if the identification is correct. Otherwise, you have to manually name "+
             "one or a few spots in the next step.</p>";
     private static final String HELP_SETINDICES2 =
@@ -210,7 +211,7 @@ public class LeedSpotTrackerHelp {
             "In case of a mistake, you can click on a spot and rename it. As soon as the program has tried to identify "+
             "the spot pattern, the input window also shows the polynomial order it uses to convert reciprocal-space "+
             "coordinates to pixel coordinates and the root-mean-square (rms) deviation of the spots from the fit "+
-            "in pixels. For small images (e.g. 512 x 512 pixels), the rms deviation should not be much more than about "+
+            "in pixels. For small images (e.g., 512 x 512 pixels), the rms deviation should not be much more than about "+
             "two pixels; otherwise carefully check whether the assignment is correct (especially if spots are dense "+
             "in some places, but with larger gaps in between, as it happens for some superstructure cells). "+
             "Especially in case of distorted images, one can also "+
@@ -234,7 +235,7 @@ public class LeedSpotTrackerHelp {
             "due to inelastic scattering is very low and flat, and (iii) all spots are bright. "+
             "Even in case of very close spots and high noise, the radius values should not be less than ~2 times "+
             "the typical spot radii. This means that the line in the "+
-            "<a href='#spotRadii'>spot radii plot</a> should still be above the center of the point cloud). "+
+            "<a href='#spotRadii'>spot radii plot</a> should still be above the center of the point cloud. "+
             "Usually it is a good idea to try spot tracking with different radii and compare the "+
             "<a href='#qualityPlot'><i>I</i>(<i>V</i>) quality plots</a> to find out which value works best. "+
             "Keep in mind that the radii must be chosen such that the background area of each spot "+
@@ -270,7 +271,9 @@ public class LeedSpotTrackerHelp {
             "(This is the opposite to the oval background, where the background is evaluated in tangential direction from the spot.)</p>"+
             "<p>For both <em>Oval background</em> and <em>Azimuth blur</em>, note that there is no thorough checking "+
             "for whether the background area of a spot overlaps with the integration disk of any of its neighbors. "+
-            "Thus, use these modes only if the spots are well-separated up to the highest energy. </p>";
+            "Thus, use these modes only if the spots are well-separated up to the highest energy.</p>"+
+            "<p>The type and size of the integration and background areas are indicated at the top right of the SpotTracking stack. "+
+            "(Not updated while the dialog is open.)</p>";
     private static final String HELP_TRACKSPOTS1 =
             "<h2><a name='trackSpots'>Track Spots</a></h2>"+
             "<p>Starts spot tracking and intensity measurements (may take up to a minute). "+
@@ -312,7 +315,7 @@ public class LeedSpotTrackerHelp {
             "Then, for spots that are below the noise threshold at all energies, the positions "+
             "are inferred from the neighboring stronger spots. This is useful, e.g., for checking whether minority areas with a "+
             "given superstructure are present. "+
-            "In this case, check the positions and make sure you don't mistake small background variations for a real signal!</dd>"+
+            "In this case, check the positions and make sure you don't mistake small background variations for a real signal.</dd>"+
             "<dt>Subtract background of bright neighbor spots:</dt><dd>Since spots often have a long-range background "+
             "(tails of the spot profile), the background for nearby spots is not uniform. "+
             "Use this option only if the spots show circular symmetry, not for elongated spots. "+
@@ -336,7 +339,7 @@ public class LeedSpotTrackerHelp {
             "i.e., when zero light corresponds to a pixel value of zero. "+
             "The ViPErLEED hardware measures I0 with very low noise; for such data it may be better to disable I0 smoothing "+
             "in case of I0 jumps instead of using this option. "+
-            "To examine whether this option works well, plot the processed I0 vs. (raw) I0 with 'More&gt;&gt;Plot...' "+
+            "To examine whether this option works well, plot the processed I0 vs. (raw) I0 with <a href='#morePlot'>More&gt;&gt;Plot...</a> "+
             "after spot tracking and check whether the processed I0 is less noisy than the raw I0. "+
             "You can also plot the background intensity divided by the (unsmoothed, but I00-corrected) I0. "+
             "Use the &quot;Apply fast background changes to I0&quot; option only if background/I0 "+
@@ -370,7 +373,8 @@ public class LeedSpotTrackerHelp {
             "<dl><dt><a name='selectedCurves'>Selected I(V) Curves</a></dt><dd>If there are symmetry-equivalent beams, "+
             "a plot of one set of such beams. "+
             "This is mainly for judging the alignment and residual electric and magnetic fields. "+
-            " (The selection criteria for this set of curves are a large common energy range and high intensity.)</dd>"+
+            " (The selection criteria for this set of curves are a large common energy range, "+
+            "a large number of equivalent beams, and high intensity.)</dd>"+
             "<dt>I(V) curves</dt><dd>The stack of all <i>I</i>(<i>V</i>) curves extracted. Note that the beam groups are in square "+
             "brackets; <i>I</i>(<i>V</i>) curves belonging to the same group should agree (symmetry-equivalent beams). "+
             "Negative group numbers denote symmetry-forbidden beams; these may have a finite (true or apparent) intensity, e.g., "+
@@ -393,26 +397,29 @@ public class LeedSpotTrackerHelp {
             "Here, 'radial' refers to the direction to the screen center, except for 'azimuth blur' mode, where "+
             "the radial direction is defined as the direction to the (0,0) spot. "+
             "The spot size plotted is an approximation to the standard deviation &sigma; of a Gaussian peak. "+
-            "Since the peaks are usually not Gaussians the sizes depend somewhat on the integration radius. "+
+            "Since the peaks are usually not Gaussians, the sizes depend somewhat on the integration radius. "+
             "The plot also shows a line with half the integration radius; it should trace the center of the point cloud "+
             "or be at larger radius values than the center line of the cloud. Ignore the outliers, "+
             "these are usually very weak spots. In &quot;azimuth blur&quot; mode, "+
-            "the tangential size of the spots is scaled down, as if the integration ellipse "+
-            "together with the image were compressed into a circle. Nevertheless, in &quot;azimuth blur&quot; mode, this criterion "+
-            "is mainly relevant for the size &sigma; in radial direction. It is less important in azimuthal direction "+
+            "the tangential size of the spots is scaled down, as if the image was distorted to make the integration ellipses circular. "+
+            "Nevertheless, in &quot;azimuth blur&quot; mode, this criterion "+
+            "is mainly relevant for the size &sigma; in the radial direction. It is less important in the azimuthal direction "+
             "because the background area does not extend from the ellipse in azimuthal direction. "+
             "See <a href='#setRadius'>Set Integration Radius</a>.</dd>"+
             "<dt><a name='qualityPlot'>I(V) Quality Statistics</a></dt><dd>This plot shows the <i>R</i> factors between symmetry-equivalent "+
-            "beams in two ways: (1) A scatter plot, where the horizontal axis is the average intensity of the <i>I</i>(<i>V</i>) curve "+
+            "beams in various ways:<br>"+
+            "(1) A scatter plot, where the horizontal axis is the average intensity of the <i>I</i>(<i>V</i>) curve "+
             "or section of that curve (normalized to 1000 for the highest intensity occurring anywhere). "+
             "Typically, due to noise, weak beams have higher <i>R</i> factors between symmetry-equivalent beams, "+
             "i.e., the point cloud is &quot;higher&quot; on the left side of the plot. "+
-            "(2) A line that shows the <i>R</i> factor against the cumulative energy range of all curve section pairs "+
+            "If the experiment was done very well (no residual magnetic fields, sample surface exactly normal to the electron beam), "+
+            "the points for the highest intensities will have mutual <i>R</i> values of less than 0.1.<br>"+
+            "(2) A line that shows the <i>R</i> factor against the cumulative energy range of all curve-section pairs "+
             "with an <i>R</i> factor better than the given number. (If there are many symmetry-equivalent beams, this is more than "+
             "the energy range available up to that <i>R</i> factor because many pairs can be selected from one group of beams.) "+
-            "Beams where no symmetry-equivalent curves are available are ignored. "+
-            "Furthermore, if there are beams with negative intensities (after smoothing), "+
-            "there is a 3rd data set with red triangles (3): "+
+            "Beams where no symmetry-equivalent curves are available are ignored.<br>"+
+            "(3) If there are beams with negative intensities (after smoothing), "+
+            "the plot shows red triangles: "+
             "For these points, the <i>x</i> axis gives the absolute value of the most negative intensity, "+
             "and the <i>y</i> axis gives the total energy range (per beam) where the intensity is negative. "+
             "Thus, the red symbols, if any, should be as far to the bottom left as possible.</dd>"+
@@ -422,7 +429,7 @@ public class LeedSpotTrackerHelp {
             "An energy dependence of the (0,0) position can be caused by, e.g., residual (magnetic) fields "+
             "or an off-axis position of the filament in the electron source. "+
             "The text and arrow at the top right indicate the displacement of the (0,0) spot at 100&nbsp;eV vs. "+
-            "the extrapolated position at infinite energies (where the electron beam does not get deflected). "+
+            "the extrapolated position at infinite energies (where the electron beam is not deflected). "+
             "This calculation assumes magnetic fields, which yield a deflection proportional to 1/&radic;<i>E</i>. "+
             "The direction of the arrow marks the direction of the movement of the (0,0) spot in the "+
             "'SpotTracking' movie with decreasing energy. (This is valid unless the plot window is resized, "+
@@ -433,13 +440,13 @@ public class LeedSpotTrackerHelp {
             "There is also a fit line for the scale factor, which assumes that deviations are due to such work function differences. "+
             "For conventional LEED optics without additional electric fields, "+
             "large scale deviations (more than ~2&ndash;3% at 50&nbsp;eV) "+
-            "may indicate surface charging. (The deviation from the scale factor is usually much larger for MCP-LEED, "+
-            "where fringe-field electrodes are present.)</dd></dl>";
+            "may indicate surface charging. The deviation of the scale factor is usually much larger for MCP-LEED, "+
+            "where fringe-field electrodes are present.</dd></dl>";
     private static final String HELP_SAVEDATA =
             "<h2><a name='saveData'>Save Data</a></h2>"+
             "<p>Saves the results as csv files in a directory chosen by the user. </p>"+
             "<p>The user can choose a prefix (all file names start with this) and also select whether to "+
-            "save plots (as created by 'Track Spots') and the processed image stack (usually a big file!).</p>"+
+            "save plots (as created by 'Track Spots') and the processed image stack (usually a big file).</p>"+
             "<p>Files created:</p>"+
             "<ul>"+
             "<li>The main outcome: The intensities, corrected for the (processed) beam current I0, file <tt>&lt;prefix&gt;_IVcurves.csv</tt>. "+
@@ -447,27 +454,27 @@ public class LeedSpotTrackerHelp {
             "comparison with the calculated ones.</li>"+
             "<li>The uncorrected intensities (not taking I0 into account) are written into <tt>_rawInt.csv</tt>. "+
             "For all beams tracked also the following information is "+
-            "written as csv files: The <i>x</i> &amp; <i>y</i> positions (in pixels) as well as the raw "+
+            "written as csv files: The <i>x</i> and <i>y</i> positions (in pixels) as well as the raw "+
             "and smoothed deviations of the positions from the expected ones "+
             "(<tt>_x</tt>, <tt>_y</tt>, <tt>_dx_raw</tt>, <tt>_dy_raw</tt>, <tt>_dx_smooth</tt>, <tt>_dy_smooth</tt>), "+
             "the significance (set to ~0 when it is below the noise threshold; file <tt>_signif</tt>), "+
             "the spot radii in radial and tangential direction (<tt>_rSize</tt>, <tt>_tSize</tt>; "+
             "see <a href='#spotRadii'>Spot Radii</a>), "+
-            "as well as the intensity in the background around the circle and its standard deviation "+
+            "as well as the intensity in the background region around the integration area and its standard deviation "+
             "(<tt>_backgr</tt>, <tt>_bsigma</tt>).</li>"+
             "<li>A <tt>.log</tt> file, which contains the parameters used for spot tracking.</li>"+
             "<li>If 'Save Plots' is selected, one file for each of the plots mentioned "+
             "in the <a href='#trackSpots'>'Track Spots' help</a> is saved.</li>"+
             "<li>If 'Save Stack' is selected, the 'spotTracking' image stack is saved, i.e., the input with dark/flat "+
-            "corrections applied and labeled integration circles (a large file!). "+
-            "Otherwise, one image with beam index designations (<tt>spotIndicesImage.tif.zip</tt>) is saved "+
+            "corrections applied and labeled integration circles (a large file). "+
+            "Otherwise, one image with beam-index designations (<tt>spotIndicesImage.tif.zip</tt>) is saved "+
             "(at the energy of <a href='#setIndices'>Set Indices</a>). "+
             "The image or stack is saved in .tif.zip format. It should be opened in ImageJ without prior unpacking.</li>"+
             "</ul>";
     private static final String HELP_MOREMENU =
             "<h2>More&gt;&gt; Popup Menu</h2>"+
             "<dl>"+
-            "<dt>Open Images/Movies...</dt><dd>Displays a dialog for opening the input files. Files selected as "+
+            "<dt><a name='openImagesMovies'>Open Images/Movies...</a></dt><dd>Displays a dialog for opening the input files. Files selected as "+
             "input that do not fit the requirements (e.g., wrong size, or a mask that is not a binary image) "+
             "will be opened, but not selected as the respective input. "+
             "Opening all files using this command is usually more convenient than opening and selecting them individually. "+
@@ -479,19 +486,19 @@ public class LeedSpotTrackerHelp {
             "<dt><a name='createMask'>Create mask...</a></dt><dd>Facilitates creating a mask for a stack of LEED images. "+
             "If a flat field is available, the tool is based on the flat field as an input (averaging over the stack slices); "+
             "otherwise it uses the main input stack (the standard deviation of the intensity vs. energy for each pixel). "+
-            "There are two sliders: Initially move the threshold slider to obtain a smooth outline of the screen area "+
-            "and the edge of the electron source (with the arm holding it). "+
+            "There are two sliders: Initially, move the threshold slider to obtain a smooth outline of the screen area "+
+            "and of the edge of the electron source (with the arm holding it). "+
             "In the second step, you may shrink or grow that area by a few pixels to refine it. "+
-            "In addition, if the program could guess the outline of the LEED screen, you can select "+
-            "&quot;Limit to elliptical fit&quot; and you can try to correct for the "+
+            "In addition, if the program can guess the outline of the LEED screen, you can select "+
+            "&quot;Limit to elliptical fit&quot; and you can try the checkbox to correct for the "+
             "radius dependence of the intensity, which is typically present in the input images. "+
-            "To evaluate the result, you may use Image&gt;Adjust&gt;Brightness&amp;Contrast "+
+            "To evaluate the result, you may use <i>Image&gt;Adjust&gt;Brightness&amp;Contrast</i> "+
             "to better see the border of the LEED image in the &quot;SpotTracking&quot; stack. "+
-            "When done, select the mask created in the man Spot Tracker panel. "+
+            "When done, select the mask created in the main Spot Tracker panel. "+
             "If required, use the standard "+
             "<a href='https://imagej.net/ij/docs/guide/146-19.html'>ImageJ selection tools</a> "+
             "(oval, polygon, freehand) "+
-            "and the Edit&gt;Fill, Clear and Clear Outside commands to further refine the mask.</dd>"+
+            "and the <i>Edit&gt;Fill</i>, <i>Clear</i> and <i>Clear Outside</i> commands to further refine the mask.</dd>"+
             "<dt>Highlight beams...</dt><dd>Shows the selected beam(s) with a thicker circle. Useful in case "+
             "of complex superstructures and to delete these from the output (see &quot;Delete highlighted beams...&quot;, below).</dd>"+
             "<dt><a name='deleteHighlighted'>Delete highlighted beams...</a></dt><dd>Deletes these beams completely or in a given energy range. "+
@@ -503,7 +510,7 @@ public class LeedSpotTrackerHelp {
             "Beam group, number of data points, energy of the first and last data point, "+
             "highest significance, and the energy where the highest significance is achieved. "+
             "There is also a summary line with the total numbers and overall minima/maxima.</dd>"+
-            "<dt>Plot...</dt><dd>Creates a plot of various data available. Examples include (processed) I0 or "+
+            "<dt><a name='morePlot'>Plot...</a></dt><dd>Creates a plot of various data available. Examples include (processed) I0 or "+
             "data for the beam(s) requested, such as intensity. See the list of .csv files in "+
             "<a href='#saveData'>Save Data</a> for the items available.</dd>"+
             "<dt>Close plots...</dt><dd>Closes all or a given subset of plots created by 'Track Spots'.</dd>"+
@@ -521,21 +528,25 @@ public class LeedSpotTrackerHelp {
             "overall deviations caused by residual fields are taken into account. "+
             "The output can be normalized, by dividing by the processed I0 (if available), to eliminate "+
             "brightness variations due to changes of the incident electron beam current. "+
-            "The output of stack undistortion is a virtual stack with caching. Thus, the images are created only "+
-            "when needed. This means that the output is quickly visible, but some image operations "+
-            "using the undistorted output will be initially slow, until all slices of that stack have been created. "+
-            "Note that averaging over the slices of an undistorted stack (Image&gt;Stacks&gt;Z Project) "+
+            "The output of stack undistortion is a virtual stack with caching. "+
+            "Thus, the images are created only when needed. This means that the output is quickly visible, "+
+            "but some image operations using the undistorted output will be initially slow, "+
+            "until all slices of that stack have been created. "+
+            "This also means that the stack created may become partly or fully unavailable "+
+            "when one of the input images/stacks is closed. "+
+            "Note that averaging over the slices of an undistorted stack "+
+            "(<i>Image&gt;Stacks&gt;Z Project...</i>) "+
             "requires ImageJ version 1.54j or later. "+
-            "Further processing of the undistorted stack (e.g. background subtraction, resizing) "+
-            "requires that you duplicate the output stack.</dd>"+
+            "Further processing of the undistorted stack (e.g., background subtraction, resizing) "+
+            "requires that you duplicate this stack.</dd>"+
             "<dt>List parameters</dt><dd>Creates a table with all numeric parameters; mainly for debugging. "+
-            "When in macro-recording mode (Plugins&gt;Macros&gt;Record...), "+
+            "When in macro-recording mode (<i>Plugins&gt;Macros&gt;Record...</i>), "+
             "also writes the macro commands for setting all parameter values to the Recorder window.</dd>"+
             "<dt>Read parameters from log file...</dt><dd>Reads all parameters from a user-selectable file, usually "+
-            "a <tt>_log.txt</tt> file saved in a previous spot tracking session. (Experts might also modify the "+
+            "a <tt>_log.txt</tt> file saved in a previous spot-tracking session. (Experts might also modify the "+
             "machine-readable part of such a log file to create a setup file; better use a macro for this.)</dd>"+
             "<dt>Compare parameters with log file...</dt><dd>Reads all numeric parameters from a user-selectable file, "+
-            "usually a <tt>_log.txt</tt> file saved in a previous spot tracking session, and compares it with "+
+            "usually a <tt>_log.txt</tt> file saved in a previous spot-tracking session, and compares it with "+
             "the parameters of the current session (shows a table of differences).</dd>"+
             "<dt>Metadata keywords...</dt><dd>Defines the names (case-sensitive) of data columns for energy, "+
             "I0, ... in the input files.  Separate multiple possibilities with a vertical bar. The keywords should be the full prefix, "+
@@ -550,32 +561,34 @@ public class LeedSpotTrackerHelp {
             "required next.</p>"+
             "<p>The <tt>Enter</tt> key brings the main ImageJ panel to the foreground. When the Spot Tracker panel is "+
             "in the foreground, <tt>SHIFT-Enter</tt> brings the 'SpotTracking' image stack to the foreground.</p>"+
-            "<p>In ImageJ, <i>slices</i> are the single images that an <i>image stack</i> (e.g. a movie) consists of. "+
+            "<p>In ImageJ, <i>slices</i> are the single images that an <i>image stack</i> (e.g., a movie) consists of. "+
             "Keyboard shortcuts for moving to the previous/next slice are ',' or '&lt;', and '.' or '&gt;', respectively. "+
             "You can also use the mouse wheel. "+
             "Right-click on the animation (play) symbol at the bottom left to change the speed of playing a movie "+
             "(it may be slower than the speed in frames per second, fps, if calculating the frames takes time).</p>"+
             "<p>If you have a movie with strong brightness variations, you may try setting 'Auto contrast stacks' "+
-            "in Edit&gt;Options&gt;Appearance. Bright spots will get saturated, but you may better see the faint ones.</p>"+
+            "in <i>Edit&gt;Options&gt;Appearance...</i>&nbsp; Bright spots will appear saturated, but you may better see the faint ones.</p>"+
             "<p>Why is there a <tt>(V)</tt> at the end of title of many image stacks? The <tt>(V)</tt> stands for "+
             "<i>virtual stack</i>, i.e., the images are not in memory but read from disk or calculated on the fly if "+
             "required. The stack named <tt>..._SpotTracking</tt> (created by the ViPErLEED Spot Tracker) is a virtual "+
             "stack with caching; its slices are kept in memory as long as there is sufficient memory. "+
             "You can click on the status line at the bottom of the main ImageJ toolbar to see the used and total memory. "+
-            "Use Edit&gt;Options&gt;Memory&amp;Threads to change the maximum amount of "+
+            "Use <i>Edit&gt;Options&gt;Memory&amp;Threads...<i> to change the maximum amount of "+
             "memory allocated to ImageJ (requires restarting ImageJ thereafter; "+
-            "make sure you allocate less than the RAM available in your computer!)</p>"+
+            "make sure you allocate less than the RAM available in your computer).</p>"+
             "<p>If you get an error message saying that all memory has been used, it may help to add"+
             "<pre>   -XX:SoftRefLRUPolicyMSPerMB=100</pre> "+
             "to the options for the Java Virtual Machine (JVM). These options are in the ImageJ.cfg file in the ImageJ folder. "+
             "On MacOS, these options are in the info.plist inside the ImageJ package: "+
             "Right-click on ImageJ in the Finder and select &quot;Show package contents&quot;. "+
             "The same command with a value of 10 instead of 100 would be even stronger, telling Java "+
-            "to be very restrictive with memory spent for caches; this will usually lead to longer execution times.</p>"+
+            "to be very restrictive with memory spent for caches. "+
+            "The downside is that this will usually lead to longer execution times.</p>"+
             "<p>ImageJ can save images (also image stacks and plots) as .zip files. These are compressed .tif files "+
             "that can be directly opened in ImageJ without unpacking (also by drag&amp;drop onto the status line of the main ImageJ panel). "+
-            "I(V) movies recorded as ViPErLEED .zip archives can NOT be opened by the ImageJ File&gt;Open command "+
-            "(or drag&amp;drop  on the status line); use Open LEED Movie for these.<br>"+
+            "I(V) movies recorded as ViPErLEED .zip archives can NOT be opened by the ImageJ <i>File&gt;Open</i> command "+
+            "(or drag&amp;drop  on the status line); use Open LEED Movie or "+
+            "<a href='#openImagesMovies'>More>>Open images/movies</a> for these.<br>"+
             "The file types .tif and .zip are the preferred formats for saving, since they contain the full information "+
             "and image resolution. The mask can be also saved as .png file. "+
             "NEVER save images as .jpg unless they are meant for illustration only; even then mind that .jpg "+
@@ -585,12 +598,12 @@ public class LeedSpotTrackerHelp {
             "With the mouse over the left or lower border, there are also other gray symbols; "+
             "their meaning is explained in the help text appearing in the status line of the plot "+
             "when the mouse cursor is above such a symbol. <br>"+
-            "You can set the default size of plots (and final size of plot stacks) with Edit&gt;Options&gt;Plots.</p>"+
+            "You can set the default size of plots (and final size of plot stacks) with <i>Edit&gt;Options&gt;Plots...<i></p>"+
             "<p>Many functions of the "+LEED_Spot_Tracker.PLUGIN_NAME+" can be controlled and automated via "+
             "the ImageJ macro language. "+
-            "Record macro commands with Plugins&gt;Macros&gt;Record...</p>"+
+            "Record macro commands with <i>Plugins&gt;Macros&gt;Record...</i></p>"+
             "<p>For smoothing in ViPErLEED, the strength of smoothing is given as the inverse square of the noise gain for white noise. "+
-            "E.g., '9 points' means that smoothing will reduce white noise by a factor of approximately 1/3. "+
+            "E.g., '9 points' means that smoothing will reduce white noise to approximately 1/3 of its original value. "+
             "This corresponds to the noise suppression of a moving average over 9 points. "+
             "The actual smoothing algorithm averages over more points with a weight function. "+
             "For I0 data and <i>I</i>(<i>V</i>) curves a modified sinc smoother [<a href='#msSmooth'>2</a>] is used.</p>"+

--- a/src/Open_LEED_Movie.java
+++ b/src/Open_LEED_Movie.java
@@ -436,7 +436,7 @@ public class Open_LEED_Movie extends VirtualStack implements PlugIn {
         StringBuilder label = new StringBuilder(100);
         String[] headings = rt.getHeadings();
         String[] shortHeadings = headings.clone();
-        for (int i=0; i<headings.length; i++) {     //shorter names for stack slice labels (these will be truncated for display)
+        for (int i=0; i<headings.length; i++) {     //shorter names for stack slice labels (these may be truncated for display)
             if ("energy".equalsIgnoreCase(shortHeadings[i]))
                 shortHeadings[i] = "E";
             else if ("time".equalsIgnoreCase(shortHeadings[i]) || "times".equalsIgnoreCase(shortHeadings[i]))
@@ -447,6 +447,8 @@ public class Open_LEED_Movie extends VirtualStack implements PlugIn {
                 shortHeadings[i] = "Tcj";
             else if ("I_sample".equalsIgnoreCase(shortHeadings[i]))
                 shortHeadings[i] = "Is";
+            else if ("Measured_Energy".equalsIgnoreCase(shortHeadings[i]))
+                shortHeadings[i] = "Emeas";
             else if ("label".equalsIgnoreCase(shortHeadings[i]) ||
                     "date".equalsIgnoreCase(shortHeadings[i]) ||
                     "clock".equalsIgnoreCase(shortHeadings[i]))

--- a/src/makeViPErLEEDpluginJar.sh
+++ b/src/makeViPErLEEDpluginJar.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Creates the ViPErLEED_ImageJ_plugins.jar file with the ImageJ LEED plugins.
+# This file must be called in the plugins directory with the sources and class files.
+
+tmpfile=/tmp/$$makeViPErLEEDplugin_extracted_byte_tmp
+for i in *.class
+do
+    #major version number is the 7th byte; extract it
+    dd status='none' skip=7 count=1 bs=1 if=$i of=$tmpfile
+    #we want java6, major version number byte decimal 50, ascii '2'
+    if [ `cat $tmpfile` != "2" ] ; then
+        echo "WARNING: $i is NOT compiled for Java 6 (major version 50):"
+    fi
+done
+
+for i in Open_Aida_LEED_Video.class Open_LEED_Movie.class LEED_Spot_Tracker.class LEED_Curve_Editor.class LEED_Data_Quality_Statistics.class LEED_R_Factor_Between_Datasets.class LEED_Stitch_Datasets.class LEED_Average_Datasets.class LEED_IV_Curve_Interpolation.class LEED_IV_Curve_Tools.class LEED_Commands.class
+do
+if [ ! -f $i ]; then
+    echo "File $i not found"
+    exit 1
+fi
+done
+
+mkdir -p source/
+cp -p *LEED*.java Leed*.java source/
+zip --quiet ../ViPErLEED_.zip 00README.txt plugins.config Open_Aida_LEED_Video*.class Open_LEED_Movie*.class LEED_Spot_Tracker*.class LEED_Curve_Editor*.class LEED_R_Factor*.class LEED_Data_Quality_Statistics*.class LEED_R_Factor_Between_Datasets*.class LEED_IV_Curve_Tools*.class Leed*.class Averaging_LEED_Stack*.class Linear_Fit_LEED_Stack*.class LEED_Average_Datasets*.class LEED_IV_Curve_Interpolation*.class LEED_Stitch_Datasets*.class LEED_Commands*.class LICENSE*.txt source/*
+rm source/*.java
+mv ../ViPErLEED_.zip ../ViPErLEED_ImageJ_plugins.jar
+
+rm -f $tmpfile
+
+
+


### PR DESCRIPTION
Spot Tracker stack indicates size&shape of the integration & background areas at the top right. Minor improvements of help texts.
Spot Tracker default value for searchAgain_eV ("Search beam unseen for") reduced from 30 to 10 eV (slightly slower but works better) Spot Tracker can read energy also with key "_" if file name is my_file_150.tif Can read Spot Pattern files opened and saved in spreadsheet (Excel, LibroOffice) Spot Tracker bugfix: If the main input stack was 32-bit type and there is no dark&flat, the input could overwritten. Spot Tracker bugfix: For stacks with only two slices, position smoothing failed, causing the spots not to be measured. Spot Tracker bugfix: More>>Create Mask could cause a NullPointerException. Spot Tracker bugfix: Overlays for energy etc. could be added multiple times. Spot Tracker bugfix: More>>Compare parameters had problems if all current parameters were the same as in the log file. IV Curve Editor bugfix: CTRL (for jumping to bad-agreement group) was ignored for CTRL-click on Prev and Next buttons. IV Curve Editor bugfix: Restricting energy range could cause a NullPointerException. R Factor Between Datasets bugfix: R factor was incorrectly calculated for integer&superstructure (overall was ok)